### PR TITLE
feat: Add category management endpoints

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+DATABASE_URL=jdbc:mysql://localhost:3306/enotes
+DATABASE_USERNAME=root
+DATABASE_PASSWORD=rofix15963kengan

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ build/
 
 ### VS Code ###
 .vscode/
+.env

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,15 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/rofix/enotes_service/controller/CategoryController.java
+++ b/src/main/java/com/rofix/enotes_service/controller/CategoryController.java
@@ -1,0 +1,39 @@
+package com.rofix.enotes_service.controller;
+
+import com.rofix.enotes_service.entity.Category;
+import com.rofix.enotes_service.response.APIResponse;
+import com.rofix.enotes_service.service.CategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.CollectionUtils;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/categories")
+@RequiredArgsConstructor
+public class CategoryController {
+    private final CategoryService categoryService;
+
+    @PostMapping
+    public ResponseEntity<APIResponse<Category>> createCategory(@RequestBody Category category){
+        Category savedCategory = categoryService.saveCategory(category);
+        APIResponse<Category> response = APIResponse.<Category>builder().message("Category created successfully").data(savedCategory).build();
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<APIResponse<List<Category>>> getAllCategories(){
+        List<Category> categories =  categoryService.getAllCategories();
+
+        APIResponse<List<Category>> response = APIResponse.<List<Category>>builder()
+                .message("Get All Categories")
+                .data(categories)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/rofix/enotes_service/entity/Category.java
+++ b/src/main/java/com/rofix/enotes_service/entity/Category.java
@@ -1,0 +1,29 @@
+package com.rofix.enotes_service.entity;
+
+import com.rofix.enotes_service.entity.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "categories")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper=true)
+@SuperBuilder
+public class Category extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50, unique = true)
+    private String name;
+
+    @Column(length = 1000, nullable = false)
+    private String description;
+}

--- a/src/main/java/com/rofix/enotes_service/entity/base/BaseEntity.java
+++ b/src/main/java/com/rofix/enotes_service/entity/base/BaseEntity.java
@@ -1,0 +1,39 @@
+package com.rofix.enotes_service.entity.base;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+@MappedSuperclass
+@Getter
+@Setter
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@SuperBuilder
+public abstract class BaseEntity {
+    @Builder.Default
+    private Boolean isActive = true;
+
+    @Builder.Default
+    private Boolean isDeleted = false;
+
+    private Integer createdBy;
+
+    @CreationTimestamp
+    private Instant createdOn;
+
+    private Integer updatedBy;
+
+    @UpdateTimestamp
+    private Instant updatedOn;
+}

--- a/src/main/java/com/rofix/enotes_service/repository/CategoryRepository.java
+++ b/src/main/java/com/rofix/enotes_service/repository/CategoryRepository.java
@@ -1,0 +1,9 @@
+package com.rofix.enotes_service.repository;
+
+import com.rofix.enotes_service.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category,Long> {
+}

--- a/src/main/java/com/rofix/enotes_service/response/APIResponse.java
+++ b/src/main/java/com/rofix/enotes_service/response/APIResponse.java
@@ -1,0 +1,25 @@
+package com.rofix.enotes_service.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.*;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class APIResponse<T> {
+    private String message;
+
+    @Builder.Default
+    private T data = null;
+
+    @Builder.Default
+    private Boolean status = true;
+
+    @Builder.Default
+    private Instant timestamp = Instant.now();
+}

--- a/src/main/java/com/rofix/enotes_service/service/CategoryService.java
+++ b/src/main/java/com/rofix/enotes_service/service/CategoryService.java
@@ -1,0 +1,10 @@
+package com.rofix.enotes_service.service;
+
+import com.rofix.enotes_service.entity.Category;
+
+import java.util.List;
+
+public interface CategoryService {
+    Category saveCategory(Category category);
+    List<Category> getAllCategories();
+}

--- a/src/main/java/com/rofix/enotes_service/service/CategoryServiceImpl.java
+++ b/src/main/java/com/rofix/enotes_service/service/CategoryServiceImpl.java
@@ -1,0 +1,31 @@
+package com.rofix.enotes_service.service;
+
+import com.rofix.enotes_service.entity.Category;
+import com.rofix.enotes_service.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.ObjectUtils;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryServiceImpl implements CategoryService {
+    private final CategoryRepository categoryRepository;
+
+    @Override
+    public Category saveCategory(Category category) {
+        Category newCategory = Category.builder().
+                name(category.getName())
+                .description(category.getDescription())
+                .createdBy(1)
+                .build();
+
+        return categoryRepository.save(newCategory);
+    }
+
+    @Override
+    public List<Category> getAllCategories() {
+        return categoryRepository.findAll();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,9 @@
 spring.application.name=enotes-service
+
+spring.datasource.url=${DATABASE_URL}
+spring.datasource.username=${DATABASE_USERNAME}
+spring.datasource.password=${DATABASE_PASSWORD}
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.hibernate.ddl-auto=none
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
This commit introduces two new API endpoints:
- A POST endpoint for creating a new category.
- A GET endpoint to retrieve all available categories from the database.

Changes include:
- `CategoryController.java`: Added `@PostMapping` and `@GetMapping` methods.
- `CategoryService.java`: Added `createCategory()` and `getAllCategories()` methods.
- `CategoryRepository.java`: Added Category Respository.