### PR TITLE
feat: Add API endpoints for category retrieval and deletion

### DIFF
--- a/src/main/java/com/rofix/enotes_service/controller/CategoryController.java
+++ b/src/main/java/com/rofix/enotes_service/controller/CategoryController.java
@@ -2,15 +2,15 @@ package com.rofix.enotes_service.controller;
 
 import com.rofix.enotes_service.dto.request.CategoryRequestDTO;
 import com.rofix.enotes_service.dto.response.CategoryResponseDTO;
-import com.rofix.enotes_service.entity.Category;
 import com.rofix.enotes_service.response.APIResponse;
 import com.rofix.enotes_service.service.CategoryService;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.CollectionUtils;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -18,6 +18,7 @@ import java.util.List;
 @RestController
 @RequestMapping(value = "/api/v1/categories", produces = MediaType.APPLICATION_JSON_VALUE)
 @RequiredArgsConstructor
+@Validated
 public class CategoryController {
     private final CategoryService categoryService;
 
@@ -54,5 +55,28 @@ public class CategoryController {
                 .build();
 
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<APIResponse<CategoryResponseDTO>> getCategory(@Min(value = 1) @PathVariable Long id) throws Exception {
+        CategoryResponseDTO category = categoryService.getCategoryById(id);
+
+        APIResponse<CategoryResponseDTO> categoryResponseDTO = APIResponse.<CategoryResponseDTO>builder()
+                .message("Get Category")
+                .data(category)
+                .build();
+
+        return ResponseEntity.ok(categoryResponseDTO);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<APIResponse<Void>> deleteCategory(@Min(value = 1) @PathVariable Long id) {
+        String status = categoryService.deleteCategoryById(id);
+
+        APIResponse<Void> categoryResponseDTO = APIResponse.<Void>builder()
+                .message(status)
+                .build();
+
+        return ResponseEntity.ok(categoryResponseDTO);
     }
 }

--- a/src/main/java/com/rofix/enotes_service/helper/CategoryHelper.java
+++ b/src/main/java/com/rofix/enotes_service/helper/CategoryHelper.java
@@ -1,0 +1,31 @@
+package com.rofix.enotes_service.helper;
+
+import com.rofix.enotes_service.dto.response.CategoryResponseDTO;
+import com.rofix.enotes_service.entity.Category;
+import com.rofix.enotes_service.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class CategoryHelper {
+    private final CategoryRepository categoryRepository;
+    private final ModelMapper modelMapper;
+
+    public List<CategoryResponseDTO> getCategoryResponseDTO(List<Category> categoryList)
+    {
+        return categoryList.stream()
+                .map(category -> modelMapper.map(category, CategoryResponseDTO.class))
+                .toList();
+    }
+
+    public Category getByIdAndActiveAndNotDeletedOrThrow(Long id)
+    {
+        return categoryRepository.findByIdAndIsDeletedIsFalseAndIsActiveIsTrue(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "category with Id " + id + " not found" ));
+    }
+}

--- a/src/main/java/com/rofix/enotes_service/repository/CategoryRepository.java
+++ b/src/main/java/com/rofix/enotes_service/repository/CategoryRepository.java
@@ -2,12 +2,14 @@ package com.rofix.enotes_service.repository;
 
 import com.rofix.enotes_service.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface CategoryRepository extends JpaRepository<Category,Long> {
-    List<Category> findByIsActiveTrue();
+    List<Category> findByIsActiveTrueAndIsDeletedFalse();
+
+    Optional<Category> findByIdAndIsDeletedIsFalseAndIsActiveIsTrue(Long id);
 }

--- a/src/main/java/com/rofix/enotes_service/service/CategoryService.java
+++ b/src/main/java/com/rofix/enotes_service/service/CategoryService.java
@@ -4,6 +4,7 @@ import com.rofix.enotes_service.dto.request.CategoryRequestDTO;
 import com.rofix.enotes_service.dto.response.CategoryResponseDTO;
 import com.rofix.enotes_service.entity.Category;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 
 import java.util.List;
 
@@ -12,4 +13,8 @@ public interface CategoryService {
     List<CategoryResponseDTO> getAllCategories();
 
     List<CategoryResponseDTO> getActiveCategories();
+
+    CategoryResponseDTO getCategoryById(Long id);
+
+    String deleteCategoryById(Long id);
 }


### PR DESCRIPTION
- Implemented GET and DELETE endpoints for a single category.
- Created `CategoryHelper` class to encapsulate reusable business logic, improving code organization and reusability.
- Handled the logic for both retrieving a category and performing a soft deletion.