### PR TITLE
feat: Implement auditing for entity creation and modification

### DIFF
--- a/src/main/java/com/rofix/enotes_service/config/AppConfig.java
+++ b/src/main/java/com/rofix/enotes_service/config/AppConfig.java
@@ -3,12 +3,21 @@ package com.rofix.enotes_service.config;
 import org.modelmapper.ModelMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
+@EnableJpaAuditing(auditorAwareRef = "auditorAware")
 public class AppConfig {
     @Bean
     public ModelMapper modelMapper()
     {
         return new ModelMapper();
+    }
+
+    @Bean
+    public AuditorAware<Integer> auditorAware()
+    {
+        return new AuditorAwareImpl();
     }
 }

--- a/src/main/java/com/rofix/enotes_service/config/AuditorAwareImpl.java
+++ b/src/main/java/com/rofix/enotes_service/config/AuditorAwareImpl.java
@@ -1,0 +1,12 @@
+package com.rofix.enotes_service.config;
+
+import org.springframework.data.domain.AuditorAware;
+
+import java.util.Optional;
+
+public class AuditorAwareImpl  implements AuditorAware<Integer> {
+    @Override
+    public Optional<Integer> getCurrentAuditor() {
+        return Optional.of(1);
+    }
+}

--- a/src/main/java/com/rofix/enotes_service/dto/request/CategoryRequestDTO.java
+++ b/src/main/java/com/rofix/enotes_service/dto/request/CategoryRequestDTO.java
@@ -1,7 +1,7 @@
 package com.rofix.enotes_service.dto.request;
 
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -22,6 +22,8 @@ public class CategoryRequestDTO {
     @Size(min = 6, max = 1000, message = "The category description must be between 6 and 1000 characters long.")
     private String description;
 
+    @NotNull(message = "Category Active status cannot be null!!!")
     private Boolean isActive = true;
+
     private Boolean isDeleted = false;
 }

--- a/src/main/java/com/rofix/enotes_service/entity/Category.java
+++ b/src/main/java/com/rofix/enotes_service/entity/Category.java
@@ -4,6 +4,7 @@ import com.rofix.enotes_service.entity.base.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 
 @Entity

--- a/src/main/java/com/rofix/enotes_service/entity/base/BaseEntity.java
+++ b/src/main/java/com/rofix/enotes_service/entity/base/BaseEntity.java
@@ -1,13 +1,17 @@
 package com.rofix.enotes_service.entity.base;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -20,6 +24,7 @@ import java.time.LocalDate;
 @AllArgsConstructor
 @ToString
 @SuperBuilder
+@EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
     @Builder.Default
     private Boolean isActive = true;
@@ -27,13 +32,19 @@ public abstract class BaseEntity {
     @Builder.Default
     private Boolean isDeleted = false;
 
+    @CreatedBy
+    @Column(updatable = false)
     private Integer createdBy;
 
     @CreationTimestamp
+    @Column(updatable = false)
     private Instant createdOn;
 
+    @LastModifiedBy
+    @Column(insertable = false)
     private Integer updatedBy;
 
     @UpdateTimestamp
+    @Column(insertable = false)
     private Instant updatedOn;
 }

--- a/src/main/java/com/rofix/enotes_service/helper/CategoryHelper.java
+++ b/src/main/java/com/rofix/enotes_service/helper/CategoryHelper.java
@@ -48,7 +48,6 @@ public class CategoryHelper {
         category.setName(categoryDTO.getName());
         category.setDescription(categoryDTO.getDescription());
         category.setIsActive(categoryDTO.getIsActive());
-        category.setUpdatedBy(1);
         category.setIsDeleted(categoryDTO.getIsDeleted());
 
         return category;

--- a/src/main/java/com/rofix/enotes_service/service/CategoryServiceImpl.java
+++ b/src/main/java/com/rofix/enotes_service/service/CategoryServiceImpl.java
@@ -3,8 +3,6 @@ package com.rofix.enotes_service.service;
 import com.rofix.enotes_service.dto.request.CategoryRequestDTO;
 import com.rofix.enotes_service.dto.response.CategoryResponseDTO;
 import com.rofix.enotes_service.entity.Category;
-import com.rofix.enotes_service.exception.base.ConflictException;
-import com.rofix.enotes_service.exception.base.NotFoundException;
 import com.rofix.enotes_service.helper.CategoryHelper;
 import com.rofix.enotes_service.repository.CategoryRepository;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +26,6 @@ public class CategoryServiceImpl implements CategoryService {
        categoryHelper.checkedCategory(categoryDTO.getName(), null);
 
         Category newCategory = modelMapper.map(categoryDTO, Category.class);
-        newCategory.setCreatedBy(1);
         Category savedCategory = categoryRepository.save(newCategory);
         log.info("[CategoryServiceImpl] :: [saveCategory] :: Category has been Saved Successfully...");
 


### PR DESCRIPTION
- Configured Spring Data JPA Auditing to automatically populate 'createdBy' and 'updatedBy' fields.
- Applied `@CreatedBy` and `@LastModifiedBy` annotations to the relevant fields in `BaseEntity` (or directly in `Category` if `BaseEntity` isn't used for auditing).
- Ensured proper integration with existing data models for seamless auditing.